### PR TITLE
Feat/adjustments after testing

### DIFF
--- a/src/common/helpers/template.helper.ts
+++ b/src/common/helpers/template.helper.ts
@@ -105,11 +105,13 @@ export default class TemplateHelpers {
 {{/jsonFormatter}}`,
     itemXML: `<{{tag}} {{#each properties as |prop|}}
 {{~#if (and (ne @key "children") (ne @key "meta"))}}{{prop}}="{{lookup ../item @key}}" {{/if}}
-{{~/each}}{{~#unless (or item.meta (length item.children))}}/>{{else}}>
+{{~/each}}{{~#unless (or (and properties.meta item.meta) (length item.children))}}/>{{else}}>
 {{#withIndent spaces=2}}
+{{~#if properties.meta }}
 {{~#each item.meta as |meta|}}
 <{{lookup (lookup ../properties "meta") "tag"}} {{lookup (lookup ../properties "meta") "key"}}="{{@key}}" {{lookup (lookup ../properties "meta") "value"}}="{{meta}}" />
 {{~/each}}
+{{~/if}}
 
 {{~#each item.children as |child|}}
 

--- a/src/common/helpers/template.helper.ts
+++ b/src/common/helpers/template.helper.ts
@@ -96,7 +96,11 @@ export default class TemplateHelpers {
     {{/each}}
   ],
   {{else if (and (eq @key "meta") ../item.meta) }}
-  "{{prop}}": {{{json ../item.meta}}}{{#unless @last}},{{/unless}}
+  "{{prop.key}}": {
+    {{~#each ../item.meta as |meta|}}
+    "{{#if (and prop.mapKeys (lookup prop.mapKeys @key))}}{{lookup prop.mapKeys @key}}{{else}}{{@key}}{{/if}}": {{{json meta}}}{{#unless @last}},{{/unless}}
+    {{~/each}}
+  }{{#unless @last}},{{/unless}}
   {{else if (and (ne @key "children") (ne @key "meta"))}}
   "{{prop}}": "{{lookup ../item @key}}"{{#unless @last}},{{/unless}}
   {{/if}}

--- a/src/common/helpers/template.helper.ts
+++ b/src/common/helpers/template.helper.ts
@@ -106,10 +106,14 @@ export default class TemplateHelpers {
     itemXML: `<{{tag}} {{#each properties as |prop|}}
 {{~#if (and (ne @key "children") (ne @key "meta"))}}{{prop}}="{{lookup ../item @key}}" {{/if}}
 {{~/each}}{{~#unless (or (and properties.meta item.meta) (length item.children))}}/>{{else}}>
-{{#withIndent spaces=2}}
+
+{{~#withIndent spaces=2}}
+
 {{~#if properties.meta }}
 {{~#each item.meta as |meta|}}
-<{{lookup (lookup ../properties "meta") "tag"}} {{lookup (lookup ../properties "meta") "key"}}="{{@key}}" {{lookup (lookup ../properties "meta") "value"}}="{{meta}}" />
+
+<{{lookup (lookup ../properties "meta") "tag"}} {{lookup (lookup ../properties "meta") "key"}}="{{#if (and ../properties.meta.mapKeys (lookup ../properties.meta.mapKeys @key))}}{{lookup ../properties.meta.mapKeys @key}}{{else}}{{@key}}{{/if}}" {{lookup (lookup ../properties "meta") "value"}}="{{meta}}" />
+
 {{~/each}}
 {{~/if}}
 

--- a/src/common/helpers/template.helper.ts
+++ b/src/common/helpers/template.helper.ts
@@ -95,7 +95,7 @@ export default class TemplateHelpers {
     {{/if}},
     {{/each}}
   ],
-  {{else if (and (eq @key "meta") meta) }}
+  {{else if (and (eq @key "meta") ../item.meta) }}
   "{{prop}}": {{{json ../item.meta}}}{{#unless @last}},{{/unless}}
   {{else if (and (ne @key "children") (ne @key "meta"))}}
   "{{prop}}": "{{lookup ../item @key}}"{{#unless @last}},{{/unless}}

--- a/src/menu-items/menu-items.service.ts
+++ b/src/menu-items/menu-items.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
+import Handlebars from 'handlebars';
 import { Menu } from 'src/menus/entities/menu.entity';
 import { EntityManager, Repository } from 'typeorm';
 import { CreateMenuItemInput } from './inputs/create-menu-item.input';
@@ -10,6 +11,11 @@ import { InputAction } from 'src/common/schema/enums/input-action.enum';
 import { EntityNotFoundError } from 'src/common/errors/entity-not-found.error';
 import { TemplateFormat } from 'src/common/enums/template-format.enum';
 import { BadTemplateFormatError } from 'src/menus/errors/bad-template-format.error';
+import { RenderMenuItemTemplateInput } from 'src/menus/inputs/render-menu-item-template.input';
+import TemplateHelpers from 'src/common/helpers/template.helper';
+import { RenderMenuTemplateInput } from 'src/menus/inputs/render-menu-template.input';
+import { IMenuItemMeta } from 'src/common/types';
+import { MenuMeta } from 'src/menus/objects/menu-meta.object';
 
 @Injectable()
 export class MenuItemsService {
@@ -82,9 +88,10 @@ export class MenuItemsService {
     delete input.children;
     let existingItem;
     try {
-      existingItem = await manager
-        .getRepository(MenuItem)
-        .findOneOrFail({ where: { id: input.id, menuId: menu.id } });
+      existingItem = await manager.getRepository(MenuItem).findOneOrFail({
+        where: { id: input.id, menuId: menu.id },
+        relations: ['children'],
+      });
     } catch (error) {
       throw new EntityNotFoundError(MenuItem, input.id);
     }
@@ -93,8 +100,23 @@ export class MenuItemsService {
         (templateFormat && templateFormat === TemplateFormat.JSON) ||
         (!templateFormat && existingItem.templateFormat === TemplateFormat.JSON)
       ) {
+        const inputChildren = await existingItem.children;
+        const inputItem: RenderMenuItemTemplateInput = {
+          ...existingItem,
+          template,
+          templateFormat: TemplateFormat.JSON,
+          children: inputChildren,
+        };
+        const inputMenu: RenderMenuTemplateInput = {
+          ...menu,
+          items: [inputItem],
+        };
         try {
-          JSON.parse(template);
+          const renderedTemplate = this.renderMenuItemTemplate(
+            inputItem,
+            inputMenu,
+          );
+          JSON.parse(renderedTemplate);
         } catch (err) {
           throw new BadTemplateFormatError(err);
         }
@@ -191,4 +213,98 @@ export class MenuItemsService {
         throw new Error('unexpected action');
     }
   }
+
+  renderMenuItemTemplate(
+    item: RenderMenuItemTemplateInput,
+    menu: RenderMenuTemplateInput,
+  ): string {
+    const children = item.children
+      ?.map((item: RenderMenuItemTemplateInput) =>
+        this.getItemForTemplate(item, menu),
+      )
+      .sort((a, b) => a.order - b.order);
+    const meta = this.getItemMetaForTemplate(item.meta, menu);
+    if (!item.template) return '';
+    try {
+      TemplateHelpers.setup();
+      const result = Handlebars.compile(item.template)({
+        item: {
+          ...item,
+          meta,
+          children,
+        },
+      });
+      if (item.templateFormat === TemplateFormat.JSON) {
+        JSON.parse(result);
+      }
+      return result;
+    } catch (err) {
+      console.error(err);
+      throw new BadTemplateFormatError(err);
+    }
+  }
+
+  getItemForTemplate(
+    item: RenderMenuItemTemplateInput,
+    menu: RenderMenuTemplateInput,
+  ) {
+    const getChildren = (
+      parent: RenderMenuItemTemplateInput,
+    ): RenderMenuItemTemplateInput[] => {
+      const children = parent.children
+        ?.filter((item) => item.parentId === parent.id)
+        .map((item: RenderMenuItemTemplateInput) => {
+          const meta = this.getItemMetaForTemplate(item.meta, menu);
+          const children = getChildren(item);
+          TemplateHelpers.setup();
+          if (item.template) {
+            item.template = Handlebars.compile(item.template)({
+              item: {
+                ...item,
+                meta,
+                children,
+              },
+            });
+          }
+          return {
+            ...item,
+            meta,
+            children,
+          };
+        })
+        .sort((a, b) => a.order - b.order);
+      return children;
+    };
+    const meta = this.getItemMetaForTemplate(item.meta, menu);
+    const children = getChildren(item);
+    TemplateHelpers.setup();
+    if (item.template) {
+      item.template = Handlebars.compile(item.template)({
+        item: {
+          ...item,
+          meta,
+          children,
+        },
+      });
+    }
+    return {
+      ...item,
+      meta,
+      children,
+    };
+  }
+
+  private getItemMetaForTemplate = (
+    meta: IMenuItemMeta,
+    menu: RenderMenuTemplateInput,
+  ): Record<string, unknown> => {
+    const result: Record<string, unknown> = {};
+    if (!meta) return result;
+    menu.meta?.forEach((item: MenuMeta) => {
+      if (item.enabled) {
+        result[item.name] = meta[item.id] || item.defaultValue;
+      }
+    });
+    return result;
+  };
 }

--- a/src/menu-items/objects/menu-item-initial-template.object.ts
+++ b/src/menu-items/objects/menu-item-initial-template.object.ts
@@ -5,7 +5,7 @@ import { InitialTemplate } from 'src/common/schema/interfaces/initial-template.i
 @ObjectType({ implements: () => [InitialTemplate] })
 export default class MenuItemInitialTemplate extends InitialTemplate {
   @Field(() => String)
-  [TemplateFormat.JSON] = `{{> itemJSON item=item properties=(hash id="id" label="label" meta="meta" children="children") }}`;
+  [TemplateFormat.JSON] = `{{> itemJSON item=item properties=(hash id="id" label="label" meta=(hash key="meta") children="children") }}`;
 
   @Field(() => String)
   [TemplateFormat.XML] = `{{> itemXML item=item tag="item" properties=(hash id="id" label="label" meta=(hash tag="meta" key="key" value="value") children="children")}}`;

--- a/src/menus/errors/bad-template-format.error.ts
+++ b/src/menus/errors/bad-template-format.error.ts
@@ -1,0 +1,13 @@
+import { GraphQLError } from 'graphql';
+
+export class BadTemplateFormatError extends GraphQLError {
+  constructor(originalError: any) {
+    super(`Bad template format: ${originalError.message || originalError}`, {
+      extensions: {
+        code: 'BAD_TEMPLATE_FORMAT',
+        originalError,
+      },
+    });
+    this.name = 'BadTemplateFormatError';
+  }
+}

--- a/src/menus/menus.service.ts
+++ b/src/menus/menus.service.ts
@@ -114,8 +114,23 @@ export class MenusService {
     await queryRunner.startTransaction();
 
     try {
-      const { meta, items, ...rest } = updateMenuInput;
-      Object.assign(menu, rest);
+      const { meta, items, template, templateFormat, ...rest } =
+        updateMenuInput;
+
+      if (template) {
+        if (
+          (templateFormat && templateFormat === TemplateFormat.JSON) ||
+          (!templateFormat && menu.templateFormat === TemplateFormat.JSON)
+        ) {
+          try {
+            JSON.parse(template);
+          } catch (err) {
+            throw new BadTemplateFormatError(err);
+          }
+        }
+      }
+
+      Object.assign(menu, { ...rest, template, templateFormat });
 
       const updatedMeta = this.handleMeta(menu, meta);
       menu.meta = updatedMeta as MenuMeta[];

--- a/src/menus/menus.service.ts
+++ b/src/menus/menus.service.ts
@@ -446,6 +446,9 @@ export class MenusService {
           items,
         },
       });
+      if (menu.templateFormat === TemplateFormat.JSON) {
+        JSON.parse(result);
+      }
       return result;
     } catch (err) {
       console.error(err);
@@ -473,6 +476,9 @@ export class MenusService {
           children,
         },
       });
+      if (item.templateFormat === TemplateFormat.JSON) {
+        JSON.parse(result);
+      }
       return result;
     } catch (err) {
       console.error(err);


### PR DESCRIPTION
BREAKING CHANGE: `itemJSON` template helper `meta` property now receives a hash that may contain `key` and `mapKeys` as parameters, example:
```hbs
{{> itemJSON item=item properties=(hash id="id" label="label" meta=(hash key="meta" mapKeys=(hash myMeta="M1")) children="children") }}
```